### PR TITLE
Change range of Krystallus to 20y

### DIFF
--- a/DBM-Party-WotLK/HallsOfStone/Krystallus.lua
+++ b/DBM-Party-WotLK/HallsOfStone/Krystallus.lua
@@ -14,7 +14,7 @@ mod:RegisterEventsInCombat(
 local specWarningShatter	= mod:NewSpecialWarningMoveAway(50810, nil, nil, nil, 1, 2)
 local timerGroundSlamCD		= mod:NewCDTimer(20, 50833, nil, nil, nil, 3)
 
-mod:AddRangeFrameOption("10")
+mod:AddRangeFrameOption("20")
 
 function mod:UNIT_SPELLCAST_SUCCEEDED(_, spellName)
 	if spellName == GetSpellInfo(50827) and self:AntiSpam(5, 2) then  -- Ground Slam
@@ -22,7 +22,7 @@ function mod:UNIT_SPELLCAST_SUCCEEDED(_, spellName)
 		specWarningShatter:Play("scatter")
 		timerGroundSlamCD:Start()
 		if self.Options.RangeFrame then
-			DBM.RangeCheck:Show(10)
+			DBM.RangeCheck:Show(20)
 		end
 		elseif spellName == GetSpellInfo(50810) and self:AntiSpam(5, 3) then  -- Shatter
 		if self.Options.RangeFrame then


### PR DESCRIPTION
Changed range finder for Krystallus fight from **10y** to **20y**.

I don't know what range is the exact one needed, but 10y is not enough. Perhaps it's 15y, but it's better to be sure.